### PR TITLE
Add PlatformIO build support

### DIFF
--- a/HoverBoardGigaDevice/Inc/gd32f1x0_libopt.h
+++ b/HoverBoardGigaDevice/Inc/gd32f1x0_libopt.h
@@ -1,0 +1,32 @@
+/*!
+    \file  gd32f1x0_libopt.h
+    \brief library optional for gd32f1x0
+*/
+
+/*
+    Copyright (C) 2017 GigaDevice
+
+    2014-12-26, V1.0.0, platform GD32F1x0(x=3,5)
+    2016-01-15, V2.0.0, platform GD32F1x0(x=3,5,7,9)
+    2016-04-30, V3.0.0, firmware update for GD32F1x0(x=3,5,7,9)
+    2017-06-19, V3.1.0, firmware update for GD32F1x0(x=3,5,7,9)
+*/
+
+#ifndef GD32F1X0_LIBOPT_H
+#define GD32F1X0_LIBOPT_H
+
+#include "gd32f1x0_adc.h"
+#include "gd32f1x0_dbg.h"
+#include "gd32f1x0_dma.h"
+#include "gd32f1x0_gpio.h"
+#include "gd32f1x0_syscfg.h"
+#include "gd32f1x0_i2c.h"
+#include "gd32f1x0_fwdgt.h"
+#include "gd32f1x0_pmu.h"
+#include "gd32f1x0_rcu.h"
+#include "gd32f1x0_timer.h"
+#include "gd32f1x0_usart.h"
+#include "gd32f1x0_wwdgt.h"
+#include "gd32f1x0_misc.h"
+
+#endif /* GD32F1X0_LIBOPT_H */

--- a/HoverBoardGigaDevice/Src/bldc.c
+++ b/HoverBoardGigaDevice/Src/bldc.c
@@ -87,7 +87,7 @@ const uint8_t hall_to_pos[8] =
 //----------------------------------------------------------------------------
 // Block PWM calculation based on position
 //----------------------------------------------------------------------------
-__INLINE void blockPWM(int pwm, int pwmPos, int *y, int *b, int *g)
+static __INLINE void blockPWM(int pwm, int pwmPos, int *y, int *b, int *g)
 {
   switch(pwmPos)
 	{

--- a/HoverBoardGigaDevice/add_nanolib.py
+++ b/HoverBoardGigaDevice/add_nanolib.py
@@ -1,0 +1,3 @@
+Import("env")
+#env.Append(LINKFLAGS=["--specs=nano.specs"])
+env.Append(LINKFLAGS=["--specs=nosys.specs", "--specs=nano.specs"])

--- a/HoverBoardGigaDevice/boards/gd32f130c6.json
+++ b/HoverBoardGigaDevice/boards/gd32f130c6.json
@@ -1,0 +1,40 @@
+{
+  "build": {
+    "core": "gd32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DGD32F1x0 -DGD32F130_150 -D__GD32F130_SUBFAMILY -D__GD32F1x0_FAMILY",
+    "f_cpu": "72000000L",
+    "mcu": "gd32f130c6t6"
+  },
+  "connectivity": [
+  ],
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "GD32F130C6",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F10x.svd"
+  },
+  "frameworks": [
+    "stm32cube",
+    "spl"
+  ],
+  "name": "Generic GD32F130C6T6",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 32768,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "mbed"
+    ]
+  },
+  "url": "https://www.gigadevice.com/microcontroller/gd32f130c6t6/",
+  "vendor": "GigaDevice"
+}

--- a/HoverBoardGigaDevice/boards/gd32f130c8.json
+++ b/HoverBoardGigaDevice/boards/gd32f130c8.json
@@ -1,0 +1,40 @@
+{
+  "build": {
+    "core": "gd32",
+    "cpu": "cortex-m3",
+    "extra_flags": "-DGD32F1x0 -DGD32F130_150 -D__GD32F130_SUBFAMILY -D__GD32F1x0_FAMILY",
+    "f_cpu": "72000000L",
+    "mcu": "gd32f130c8t6"
+  },
+  "connectivity": [
+  ],
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "GD32F130C8",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_target": "stm32f1x",
+    "svd_path": "STM32F10x.svd"
+  },
+  "frameworks": [
+    "stm32cube",
+    "spl"
+  ],
+  "name": "Generic GD32F130C8T6",
+  "upload": {
+    "maximum_ram_size": 8196 ,
+    "maximum_size": 65536,
+    "protocol": "stlink",
+    "protocols": [
+      "jlink",
+      "stlink",
+      "blackmagic",
+      "mbed"
+    ]
+  },
+  "url": "https://www.gigadevice.com/microcontroller/gd32f130c8t6/",
+  "vendor": "GigaDevice"
+}

--- a/HoverBoardGigaDevice/platformio.ini
+++ b/HoverBoardGigaDevice/platformio.ini
@@ -1,0 +1,27 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = Src
+include_dir = Inc
+
+[env]
+; globally override framework-spl for all environments.
+platform_packages = 
+    maxgerhardt/framework-spl@2.10300.0
+
+[env:GD32F130C8T6]
+platform = ststm32
+board = gd32f130c8
+debug_tool = stlink
+framework = spl
+build_flags = -IInc
+extra_scripts = add_nanolib.py
+;lib_deps = file://RTE/Device/GD32F130C8

--- a/HoverBoardGigaDevice/platformio.ini
+++ b/HoverBoardGigaDevice/platformio.ini
@@ -14,12 +14,9 @@ include_dir = Inc
 
 [env]
 ; globally override framework-spl for all environments.
-; new version on the way that fixes a compile error for arm_math.h
-; for now you have to manually copy the 3 files arm_common_tables.h, arm_const_structs.h and arm_math.h
-; from C:\Users\<user>\.platformio\packages\framework-spl\stm32\cmsis\cores\stm32
-; to   C:\Users\<user>\.platformio\packages\framework-spl\gd32\cmsis\cores\gd32
+; uses self-uploaded package with GD32F suppport
 platform_packages = 
-    maxgerhardt/framework-spl@2.10300.0
+    maxgerhardt/framework-spl@2.10301.0
 
 [env:GD32F130C8T6]
 platform = ststm32
@@ -28,4 +25,3 @@ debug_tool = stlink
 framework = spl
 build_flags = -IInc
 extra_scripts = add_nanolib.py
-;lib_deps = file://RTE/Device/GD32F130C8

--- a/HoverBoardGigaDevice/platformio.ini
+++ b/HoverBoardGigaDevice/platformio.ini
@@ -14,6 +14,10 @@ include_dir = Inc
 
 [env]
 ; globally override framework-spl for all environments.
+; new version on the way that fixes a compile error for arm_math.h
+; for now you have to manually copy the 3 files arm_common_tables.h, arm_const_structs.h and arm_math.h
+; from C:\Users\<user>\.platformio\packages\framework-spl\stm32\cmsis\cores\stm32
+; to   C:\Users\<user>\.platformio\packages\framework-spl\gd32\cmsis\cores\gd32
 platform_packages = 
     maxgerhardt/framework-spl@2.10300.0
 


### PR DESCRIPTION
Adds a board definition file, a `platformio.ini` and one minor modification to the code to make it work with GCC. Should still work with Keil. 

The build system [PlatformIO](platformio.org/) is a Python tool and a VSCode extension that can build firmwares for tons of devices (STM32, ESP32, ESP8266, AVR, nRF52, ...) in a cross-platform and automatic way. 

Now one can do just 

```
> pio run 
Processing GD32F130C8T6 (platform: ststm32; board: gd32f130c8; framework: spl)
------------------------------------------------------------------------------------------------------------------------Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/ststm32/gd32f130c8.html
PLATFORM: ST STM32 (12.0.0) > Generic GD32F130C8T6
HARDWARE: GD32F130C8T6 72MHz, 8.00KB RAM, 64KB Flash
DEBUG: Current (stlink) On-board (stlink) External (blackmagic, jlink)
PACKAGES:
 - framework-spl 2.10301.0 (1.3.1)
 - toolchain-gccarmnoneeabi 1.70201.0 (7.2.1)
Warning! Cannot find a linker script for the required board! Firmware will be linked with a default linker script!
LDF: Library Dependency Finder -> http://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 1 compatible libraries
Scanning dependencies...
No dependencies
Building in release mode
Compiling .pio\build\GD32F130C8T6\src\bldc.o
Compiling .pio\build\GD32F130C8T6\src\comms.o
Compiling .pio\build\GD32F130C8T6\src\commsBluetooth.o
Compiling .pio\build\GD32F130C8T6\src\commsMasterSlave.o
Compiling .pio\build\GD32F130C8T6\src\commsSteering.o
Compiling .pio\build\GD32F130C8T6\src\it.o
Compiling .pio\build\GD32F130C8T6\src\led.o
Compiling .pio\build\GD32F130C8T6\src\main.o
Compiling .pio\build\GD32F130C8T6\src\setup.o
Compiling .pio\build\GD32F130C8T6\FrameworkCMSISVariant\startup_gd32f1x0.o
Compiling .pio\build\GD32F130C8T6\FrameworkCMSISVariant\system_gd32f1x0.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_adc.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_can.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_cec.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_cmp.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_crc.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_dac.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_dbg.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_dma.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_exti.o
Archiving .pio\build\GD32F130C8T6\libFrameworkCMSISVariant.a
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_fmc.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_fwdgt.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_gpio.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_i2c.o
Indexing .pio\build\GD32F130C8T6\libFrameworkCMSISVariant.a
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_ivref.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_misc.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_opa.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_pmu.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_rcu.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_rtc.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_slcd.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_spi.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_syscfg.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_timer.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_tsi.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_usart.o
Compiling .pio\build\GD32F130C8T6\FrameworkSPL\gd32f1x0_wwdgt.o
Archiving .pio\build\GD32F130C8T6\libFrameworkSPL.a
Indexing .pio\build\GD32F130C8T6\libFrameworkSPL.a
Linking .pio\build\GD32F130C8T6\firmware.elf
Building .pio\build\GD32F130C8T6\firmware.bin
Checking size .pio\build\GD32F130C8T6\firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [          ]   3.3% (used 272 bytes from 8196 bytes)
Flash: [==        ]  21.4% (used 14032 bytes from 65536 bytes)
=========== [SUCCESS] Took 2.34 seconds ===========
```
and the firmware is built :) 